### PR TITLE
Fix datamodule import and test initialization

### DIFF
--- a/model_training/src/rhea_train/data/__init__.py
+++ b/model_training/src/rhea_train/data/__init__.py
@@ -1,0 +1,3 @@
+"""Data loading utilities package."""
+
+__all__ = ["data_modules", "npz_dataset", "transforms", "generators"]

--- a/model_training/src/rhea_train/train.py
+++ b/model_training/src/rhea_train/train.py
@@ -2,7 +2,7 @@ import argparse, os, numpy as np, torch
 from rhea_train.utils.config import load_config
 from rhea_train.utils.randomness import seed_all, set_deterministic
 from rhea_train.utils.logging import get_logger
-from rhea_train.data.datamodules import build_loaders
+from rhea_train.data.data_modules import build_loaders
 from rhea_train.models.registry import create_model
 from rhea_train.engine.trainer_bce import train_once
 

--- a/model_training/tests/test_model_forward.py
+++ b/model_training/tests/test_model_forward.py
@@ -1,5 +1,26 @@
+"""Basic forward-pass test for registered models."""
+
+import os
+import sys
+
+import torch
+
+# Ensure the package under ``src`` is importable when running tests directly
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from rhea_train.models import auto_model  # noqa: F401  (registers model)
+from rhea_train.models.registry import create_model
+
+
 def test_forward_smoke():
-    m = create_model(name="your_model", in_dim=8, hidden_dims=[16], out_dim=3)
+    """Models from the registry should produce finite outputs."""
+    m = create_model(
+        name="auto_model",
+        input_size=8,
+        num_layers=1,
+        hidden_size=16,
+        dropout=0.0,
+    )
     x = torch.randn(4, 8)
     y = m(x)
-    assert y.shape == (4, 3) and torch.isfinite(y).all()
+    assert y.shape == (4, 1) and torch.isfinite(y).all()


### PR DESCRIPTION
## Summary
- fix `train.py` to import data loaders from `data_modules`
- add missing `__init__` for `rhea_train.data` package
- update smoke test to import registry model correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899d7e358148321a28cd8799aef76fc